### PR TITLE
Fix: Some MOD files crashing due to undefined behaviour caused by a 0-byte PCM buffer allocation

### DIFF
--- a/libAudio/genericModule/ModuleFile.cpp
+++ b/libAudio/genericModule/ModuleFile.cpp
@@ -658,7 +658,7 @@ template<typename T> void ModuleFile::itLoadPCMSample(const fd_t &fd, const uint
 {
 	auto *const Sample = dynamic_cast<ModuleSampleNative *>(p_Samples[i]);
 	const size_t Length = p_Samples[i]->GetLength() << (Sample->GetStereo() ? 1U : 0U);
-	if ((Sample->Flags & 0x01U) == 0)
+	if ((Sample->Flags & 0x01U) == 0U || Length == 0U)
 	{
 		p_PCM[i] = nullptr;
 		return;


### PR DESCRIPTION
Several MOD files contains sample definitions with no actual PCM data, hence having a length of 0.

Previously, ModuleFile.cpp would still attempt to allocate a 0-length buffer and read PCM data, even if there was no PCM data available for the sample. This would cause a crash under certain compilation conditions due to the undefined behaviour of a 0-length allocation.

This PR adds a secondary check to ensure that 0-length samples don't attempt to allocate a 0-length buffer.
